### PR TITLE
Remove version restriction on Flask

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -8,3 +8,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . /app/
 
 CMD ["python", "-m", "unittest", "tests/test_app.py"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Flask==2.0.1
+Flask


### PR DESCRIPTION
You were pinning your project to an older version of Flask which appears to
have compatibility issues with other modules. By removing that restriction
the tests pass successfully.
